### PR TITLE
Automated inline comments 

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -43,6 +43,9 @@ def github_post_webhook():
             print(commit_url)
             results = github.process_single_commit( token, commit_url )
             all_results = all_results + results
+        print("----->")
+        print(all_results)
+        print("<----")
         if all_results != []:
             print("--------- inline comment on results ----")
             for result in all_results:
@@ -51,7 +54,7 @@ def github_post_webhook():
                 path = result["file"][2:]   # the diff starts out with "b/", so remove that part
                 print( "path is : " + path )
                 position = result["position"]
-                secret2 = dummy_dummy_key_for_testing
+                secret = dummy_yummy_key_for_testing
                 comment = "Good Lord, do you realise what you have done?!  Please do not commit secrets to source code repositories!  You better revoke this right now, as I promise you that people seeing this are in the process of hacking it!"
                 github.leave_comment_on_commit( token, commit_url, path, position, comment)
         output_results(all_results)

--- a/src/app.py
+++ b/src/app.py
@@ -43,9 +43,6 @@ def github_post_webhook():
             print(commit_url)
             results = github.process_single_commit( token, commit_url )
             all_results = all_results + results
-        % print("----->")
-        % print(all_results)
-        % print("<----")
         if all_results != []:
             print("--------- inline comment on results ----")
             for result in all_results:
@@ -54,7 +51,7 @@ def github_post_webhook():
                 path = result["file"][2:]   # the diff starts out with "b/", so remove that part
                 print( "path is : " + path )
                 position = result["position"]
-                secret = dummy_gummy_key_for_testing
+                dummy_gummy_key_for_testing = "Top Secret, shhh don't tell anyone"
                 comment = "Good Lord, do you realise what you have done?!  Please do not commit secrets to source code repositories!  You better revoke this right now, as I promise you that people seeing this are in the process of hacking it!"
                 github.leave_comment_on_commit( token, commit_url, path, position, comment)
         output_results(all_results)

--- a/src/app.py
+++ b/src/app.py
@@ -43,19 +43,18 @@ def github_post_webhook():
             print(commit_url)
             results = github.process_single_commit( token, commit_url )
             all_results = all_results + results
-        output_results(all_results)
         if all_results != []:
+            print("--------- inline comment on results ----")
             for result in all_results:
                 # leave inline comments
                 commit_url = result["commit_url"]
                 path = result["file"][2:]   # the diff starts out with "b/", so remove that part
                 print( "path is : " + path )
-                secret = dummy_abc_key_for_testing
                 position = result["position"]
-                secret2 = dummy_key_for_testing
+                secret2 = dummy_dummy_key_for_testing
                 comment = "Good Lord, do you realise what you have done?!  Please do not commit secrets to source code repositories!  You better revoke this right now, as I promise you that people seeing this are in the process of hacking it!"
                 github.leave_comment_on_commit( token, commit_url, path, position, comment)
-        # print(json.dumps( content["commits"], indent = 2))
+        output_results(all_results)
         return jsonify({'success':True}), 200
     else:
         return jsonify({'message':'No Content'}), 204

--- a/src/app.py
+++ b/src/app.py
@@ -51,7 +51,7 @@ def github_post_webhook():
                 path = result["file"][2:]   # the diff starts out with "b/", so remove that part
                 print( "path is : " + path )
                 position = result["position"]
-                dummy_gummy_key_for_testing = "Top Secret, shhh don't tell anyone"
+                dummy_yummy_key_for_testing = "Top Secret, shhh don't tell anyone"
                 comment = "Good Lord, do you realise what you have done?!  Please do not commit secrets to source code repositories!  You better revoke this right now, as I promise you that people seeing this are in the process of hacking it!"
                 github.leave_comment_on_commit( token, commit_url, path, position, comment)
         output_results(all_results)

--- a/src/app.py
+++ b/src/app.py
@@ -44,6 +44,17 @@ def github_post_webhook():
             results = github.process_single_commit( token, commit_url )
             all_results = all_results + results
         output_results(all_results)
+        if all_results != []:
+            for result in all_results:
+                # leave inline comments
+                commit_url = result["commit_url"]
+                path = result["file"][2:]   # the diff starts out with "b/", so remove that part
+                print( "path is : " + path )
+                secret = dummy_abc_key_for_testing
+                position = result["position"]
+                secret2 = dummy_key_for_testing
+                comment = "Good Lord, do you realise what you have done?!  Please do not commit secrets to source code repositories!  You better revoke this right now, as I promise you that people seeing this are in the process of hacking it!"
+                github.leave_comment_on_commit( token, commit_url, path, position, comment)
         # print(json.dumps( content["commits"], indent = 2))
         return jsonify({'success':True}), 200
     else:

--- a/src/app.py
+++ b/src/app.py
@@ -43,9 +43,9 @@ def github_post_webhook():
             print(commit_url)
             results = github.process_single_commit( token, commit_url )
             all_results = all_results + results
-        print("----->")
-        print(all_results)
-        print("<----")
+        % print("----->")
+        % print(all_results)
+        % print("<----")
         if all_results != []:
             print("--------- inline comment on results ----")
             for result in all_results:
@@ -54,7 +54,7 @@ def github_post_webhook():
                 path = result["file"][2:]   # the diff starts out with "b/", so remove that part
                 print( "path is : " + path )
                 position = result["position"]
-                secret = dummy_yummy_key_for_testing
+                secret = dummy_gummy_key_for_testing
                 comment = "Good Lord, do you realise what you have done?!  Please do not commit secrets to source code repositories!  You better revoke this right now, as I promise you that people seeing this are in the process of hacking it!"
                 github.leave_comment_on_commit( token, commit_url, path, position, comment)
         output_results(all_results)

--- a/src/app.py
+++ b/src/app.py
@@ -44,14 +44,12 @@ def github_post_webhook():
             results = github.process_single_commit( token, commit_url )
             all_results = all_results + results
         if all_results != []:
-            print("--------- inline comment on results ----")
+            print("--------- inline comment happening on results ----")
             for result in all_results:
                 # leave inline comments
                 commit_url = result["commit_url"]
                 path = result["file"][2:]   # the diff starts out with "b/", so remove that part
-                print( "path is : " + path )
                 position = result["position"]
-                dummy_yummy_key_for_testing = "Top Secret, shhh don't tell anyone"
                 comment = "Good Lord, do you realise what you have done?!  Please do not commit secrets to source code repositories!  You better revoke this right now, as I promise you that people seeing this are in the process of hacking it!"
                 github.leave_comment_on_commit( token, commit_url, path, position, comment)
         output_results(all_results)
@@ -69,7 +67,6 @@ def github_post_webhook_gcp_cf(request):
         return jsonify({'message':'No Content'}), 204
     
     if 'commits' in content:
-
         all_results = []
         for commit in content["commits"]:
             commit_url = commit["url"]

--- a/src/providers/github.py
+++ b/src/providers/github.py
@@ -6,6 +6,23 @@ import requests
 from scanner import scan_diff
 from rules import read_rules
 
+
+# Github API: https://docs.github.com/en/rest/reference/repos#create-a-commit-comment
+def leave_comment_on_commit( token, commit_url, path, position, comment ):
+    org = commit_url.split('/')[3]
+    repo = commit_url.split('/')[4]
+    commit_hash = commit_url.split('/')[6]
+    api_url = 'https://api.github.com/repos/' + org + '/' + repo + '/commits/' + commit_hash + '/comments'
+    print(api_url)
+    payload = {'body': comment, 'path': path, 'position':position}
+    headers = {'user-agent': 'hcss', 'Accept': 'application/vnd.github.v3+json', 'Authorization': 'token ' + token }
+    r = requests.post(api_url, data=json.dumps(payload), headers=headers)
+
+
+
+# example: leave_comment_on_commit( token, 'https://github.com/High-Confidence-Security-Tools/hcss/commit/a259de4a63c23b25160baefa2fcdf727aae2a5bf', "src/hcss.py", 5, "donkey chicken" )
+
+
 def process_single_commit( token, commit_url ):
     """ 
     Process a single commit
@@ -23,8 +40,8 @@ def process_single_commit( token, commit_url ):
     # print(commit)
     diff_url = commit_url + ".diff"
     print(diff_url)
-    # TODO: token will need to be sent in to access private git repos
-    r = requests.get( diff_url )
+    headers = {'user-agent': 'hcss', 'Authorization': 'token ' + token }
+    r = requests.get( diff_url, headers=headers )
     diff_text = r.text
     if len(diff_text) < 1048576:
         results = scan_diff( r.text )
@@ -71,4 +88,5 @@ def process_repo( token, repo ):
         results = process_single_commit( token, commit.html_url )
         all_results = all_results + results
     return all_results
+
 

--- a/src/providers/github.py
+++ b/src/providers/github.py
@@ -2,7 +2,7 @@ from re import I
 
 from github import Github
 import requests
-
+import json
 from scanner import scan_diff
 from rules import read_rules
 

--- a/src/rules/rules.py
+++ b/src/rules/rules.py
@@ -6,7 +6,7 @@ rules = [
     {
         "id": "HCSS-0",
         "name": "dummy key for testing",
-        "regex": "dummy_[0-9a-zA-Z]*_key_for_testing",
+        "regex": "dummy_key_for_testing[a-zA-Z0-9]*",
         "validate": validate.dummy_key
     },
     {

--- a/src/rules/rules.py
+++ b/src/rules/rules.py
@@ -4,6 +4,12 @@ from rules import validate
 
 rules = [
     {
+        "id": "HCSS-0",
+        "name": "dummy key for testing",
+        "regex": "dummy_[0-9a-zA-Z]*_key_for_testing",
+        "validate": validate.dummy_key
+    },
+    {
         "id": "HCSS-1",
         "name": "RSA private key",
         "regex": "-----BEGIN RSA PRIVATE KEY-----[0-9a-zA-Zi+\/=\\\"\\s]*-----END RSA PRIVATE KEY-----",

--- a/src/rules/validate.py
+++ b/src/rules/validate.py
@@ -1,6 +1,22 @@
 from github import Github
 
 
+def dummy_key(secret):
+    """ 
+    Validate HCSS-0
+
+    This is a dummy key for testing so always returns true
+
+    Parameters:
+    secret (string): Secret to check
+
+    Returns:
+    bool: Whether it is valid or not
+    """
+
+    return True
+
+
 def rsa_private_key(secret):
     """ 
     Validate HCSS-1

--- a/src/scanner/__init__.py
+++ b/src/scanner/__init__.py
@@ -21,7 +21,9 @@ def offset_within_chunk( secret, chunk):
     index2 = secret_to_end_of_chunk.index( last_part_of_secret )    # we found the last line of the secret
     remaining_lines = len( secret_to_end_of_chunk[0:index2].splitlines() )
     
-    return lines_up_to_secret - 1 + remaining_lines
+    dummy_key_for_testing123 = "can you find this secret?"
+
+    return lines_up_to_secret - 2 + remaining_lines
 
 
 # def scan_chunk( filename, chunk, rules ):

--- a/src/scanner/__init__.py
+++ b/src/scanner/__init__.py
@@ -2,6 +2,28 @@ import re
 
 from rules.rules import rules
 
+
+# how far into the chunk is the secret?  We need this so we can do automated inline comments
+def offset_within_chunk( secret, chunk):
+   
+    index = chunk.index( secret )  # this is where are secret begins
+    lines_up_to_secret = len( chunk[0:index].splitlines() )
+
+    # secrets may be multi-lined.  We want to leave a comment at the end.  So find line number for that.
+    # This is a little hairy.  We know where the secret begins, and we need to find how many lines
+    # are in there until we get to the end.  Same approach as above...
+    # Remark: this may seem excessively complicated, i.e. why not just search for the last line of the secret in the
+    #   big chunk?  Answer:  because we need to make sure we are matching exactly the secret we are looking for.
+    #   For example, if last_part_of_secret is '---- END RSA PRIVATE KEY ----', and there are more than one in the chunk,
+    #   we don't want all our comments to fall under one of these cases.  Instead, we want once comment for each secret.
+    secret_to_end_of_chunk = chunk[index:]  # secret starts here and goes all the way to the end of the whole chunk being processed
+    last_part_of_secret = secret.splitlines()[-1]   # this is the last line of a possible multi-line secret
+    index2 = secret_to_end_of_chunk.index( last_part_of_secret )    # we found the last line of the secret
+    remaining_lines = len( secret_to_end_of_chunk[0:index2].splitlines() )
+    
+    return lines_up_to_secret - 1 + remaining_lines
+
+
 # def scan_chunk( filename, chunk, rules ):
 def scan_chunk( filename, chunk ):
     results = []
@@ -23,26 +45,41 @@ def scan_chunk( filename, chunk ):
                 results.append(result)
     return results
 
+
+
+def process_chunk( filename, chunk, line_number):
+    lines_in_chunk = len( chunk.splitlines() )
+    results = scan_chunk( filename, chunk )
+    for result in results:
+        offset = offset_within_chunk(result["secret"], chunk)
+        line_number = line_number - lines_in_chunk + offset
+        result["position"] = line_number
+    return results
+
 # def scan_diff( diff, rules ):
 def scan_diff( diff ): 
     all_results = []
     diff = diff.splitlines()
     filename = "undef"
     chunk = ""
+    line_number = 0   # need to keep track of line numbers 
     for line in diff:
-        if line[0:4] == '+++ ':         # file where lines are added
+        if line[0:4] == '+++ ':         # file with changes
             filename = line[4:]
+            line_number = 0
             chunk = ""
             print("File: " + filename)
-        elif line[0:4] == '--- ':       # previous file
+        elif line[0:4] == '--- ':       # the file before changes
             continue
-        elif line[0:2] == "@@":         # line numbers before and after
-            continue
-        elif line[0:1] == '+':
-            chunk = chunk + line[1:] + "\n"
-        elif chunk != "":
-            # results = scan_chunk( filename, chunk, rules )
-            results = scan_chunk( filename, chunk )
-            all_results = all_results + results
-            chunk = ""
+        else:
+            # these lines actually count for our automated inline commenting
+            line_number = line_number + 1
+            if line[0:1] == '+':
+                chunk = chunk + line[1:] + "\n"
+            else:
+                # we're not adding new lines so we are at the end of a chunk
+                if chunk != "":
+                    results = process_chunk( filename, chunk, line_number)
+                    all_results = all_results + results
+                    chunk = ""
     return all_results

--- a/src/scanner/__init__.py
+++ b/src/scanner/__init__.py
@@ -21,8 +21,6 @@ def offset_within_chunk( secret, chunk):
     index2 = secret_to_end_of_chunk.index( last_part_of_secret )    # we found the last line of the secret
     remaining_lines = len( secret_to_end_of_chunk[0:index2].splitlines() )
     
-    dummy_key_for_testing123 = "can you find this secret?"
-
     return lines_up_to_secret - 2 + remaining_lines
 
 


### PR DESCRIPTION
Automated inline comments seem to be working -- you will see examples below (the comments are coming from me because I'm running the flask app with my token).  

Details:

- app.py makes the calls to do the inline comments based upon the data within the results
- github.py has the functionality to leave a comment on a commit.  This assumes that the code is ran within an organisation, which I think is a fair assumption because I don't think you can get the webhook otherwise.  For example, this code resides in High-Confidence-Security-Tools organisation.
- Also in github.api, I added authorisation header for processing commits so that it will work in private repositories.
- rules.py adds a rule so we can put in dummy keys for testing purposes.  That way we can show people it works without exposing real credentials.
- validate.py returns True for dummy key.
- scanner/__init.py__ had to be changed to keep track of line numbers so we know where to put the inline comments.  A lot of effort was put into finding the last line of a possibly multi-line secret to leave the comment.  Sure, we could do first or last, I just prefer last.  Have a look at it and then I can explain more in a meeting.
- 